### PR TITLE
Add streaming AI chat responses with typing indicator

### DIFF
--- a/client/lib/data/model/chat_message.dart
+++ b/client/lib/data/model/chat_message.dart
@@ -9,6 +9,7 @@ sealed class ChatMessage with _$ChatMessage {
     required String content,
     required ChatMessageSender sender,
     required DateTime timestamp,
+    @Default(false) bool isStreaming,
   }) = _ChatMessage;
 }
 


### PR DESCRIPTION
## Summary
- extend `ChatMessage` with an `isStreaming` flag and update the presenter to stream AI responses
- insert a temporary AI message while streaming, updating it incrementally and handling errors in place
- refresh the chat UI to show a typing indicator, display partial responses, and wire the scroll controller to the list

## Testing
- not run (flutter command not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68c971b81b0c8327babd1dbe2c0a05f8