### PR TITLE
fix: ドロワーメニューから各種画面に遷移するように修正

### DIFF
--- a/client/lib/ui/component/app_drawer.dart
+++ b/client/lib/ui/component/app_drawer.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+class AppDrawer extends StatelessWidget {
+  const AppDrawer({
+    super.key,
+    required this.isTalkSelected,
+    required this.isJobMarketSelected,
+    required this.onSelectTalk,
+    required this.onSelectJobMarket,
+    required this.onSelectSettings,
+  });
+
+  final bool isTalkSelected;
+  final bool isJobMarketSelected;
+  final VoidCallback onSelectTalk;
+  final VoidCallback onSelectJobMarket;
+  final VoidCallback onSelectSettings;
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: SafeArea(
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: [
+            _buildHeader(context),
+            _buildTalkTile(context),
+            _buildJobMarketTile(context),
+            const Divider(),
+            _buildSettingsTile(context),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return DrawerHeader(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primaryContainer,
+      ),
+      child: Align(
+        alignment: Alignment.bottomLeft,
+        child: Text(
+          'メニュー',
+          style: theme.textTheme.headlineSmall?.copyWith(
+            color: theme.colorScheme.onPrimaryContainer,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTalkTile(BuildContext context) {
+    return ListTile(
+      leading: const Icon(Icons.chat),
+      title: const Text('トーク'),
+      selected: isTalkSelected,
+      onTap: () {
+        Navigator.of(context).pop();
+        if (!isTalkSelected) {
+          onSelectTalk();
+        }
+      },
+    );
+  }
+
+  Widget _buildJobMarketTile(BuildContext context) {
+    return ListTile(
+      leading: const Icon(Icons.work),
+      title: const Text('転職市場'),
+      selected: isJobMarketSelected,
+      onTap: () {
+        Navigator.of(context).pop();
+        if (!isJobMarketSelected) {
+          onSelectJobMarket();
+        }
+      },
+    );
+  }
+
+  Widget _buildSettingsTile(BuildContext context) {
+    return ListTile(
+      leading: const Icon(Icons.settings),
+      title: const Text('設定'),
+      onTap: () {
+        Navigator.of(context).pop();
+        onSelectSettings();
+      },
+    );
+  }
+}

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -59,14 +59,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       ],
     );
 
-    final settingsButton = IconButton(
-      onPressed: () {
-        Navigator.of(context).push(SettingsScreen.route());
-      },
-      tooltip: '設定を表示する',
-      icon: const Icon(Icons.settings),
-    );
-
     final clearButton = IconButton(
       onPressed: _clearChat,
       tooltip: 'チャット履歴をクリアする',
@@ -89,7 +81,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     return Scaffold(
       appBar: AppBar(
         title: title,
-        actions: [clearButton, settingsButton],
       ),
       drawer: AppDrawer(
         isTalkSelected: true,

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -5,6 +5,7 @@ import 'package:house_worker/data/service/cavivara_directory_service.dart';
 import 'package:house_worker/ui/component/app_drawer.dart';
 import 'package:house_worker/ui/component/cavivara_avatar.dart';
 import 'package:house_worker/ui/feature/home/home_presenter.dart';
+import 'package:house_worker/ui/feature/job_market/job_market_screen.dart';
 import 'package:house_worker/ui/feature/resume/resume_screen.dart';
 import 'package:house_worker/ui/feature/settings/settings_screen.dart';
 
@@ -93,8 +94,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           );
         },
         onSelectJobMarket: () {
-          Navigator.of(context).pushNamedAndRemoveUntil(
-            '/',
+          Navigator.of(context).pushAndRemoveUntil(
+            JobMarketScreen.route(),
             (route) => false,
           );
         },

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -81,6 +81,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     return Scaffold(
       appBar: AppBar(
         title: title,
+        actions: [clearButton],
       ),
       drawer: AppDrawer(
         isTalkSelected: true,

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:house_worker/data/model/chat_message.dart';
 import 'package:house_worker/data/service/cavivara_directory_service.dart';
+import 'package:house_worker/ui/component/app_drawer.dart';
 import 'package:house_worker/ui/component/cavivara_avatar.dart';
 import 'package:house_worker/ui/feature/home/home_presenter.dart';
 import 'package:house_worker/ui/feature/resume/resume_screen.dart';
@@ -9,6 +10,8 @@ import 'package:house_worker/ui/feature/settings/settings_screen.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key, required this.cavivaraId});
+
+  static const defaultCavivaraId = 'cavivara_default';
 
   /// 対象のカヴィヴァラID
   final String cavivaraId;
@@ -87,6 +90,25 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       appBar: AppBar(
         title: title,
         actions: [clearButton, settingsButton],
+      ),
+      drawer: AppDrawer(
+        isTalkSelected: true,
+        isJobMarketSelected: false,
+        onSelectTalk: () {
+          Navigator.of(context).pushAndRemoveUntil(
+            HomeScreen.route(widget.cavivaraId),
+            (route) => false,
+          );
+        },
+        onSelectJobMarket: () {
+          Navigator.of(context).pushNamedAndRemoveUntil(
+            '/',
+            (route) => false,
+          );
+        },
+        onSelectSettings: () {
+          Navigator.of(context).push(SettingsScreen.route());
+        },
       ),
       body: body,
     );

--- a/client/lib/ui/feature/job_market/job_market_screen.dart
+++ b/client/lib/ui/feature/job_market/job_market_screen.dart
@@ -2,9 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:house_worker/data/service/cavivara_directory_service.dart';
 import 'package:house_worker/data/service/employment_state_service.dart';
+import 'package:house_worker/ui/component/app_drawer.dart';
 import 'package:house_worker/ui/component/cavivara_avatar.dart';
 import 'package:house_worker/ui/feature/home/home_screen.dart';
 import 'package:house_worker/ui/feature/resume/resume_screen.dart';
+import 'package:house_worker/ui/feature/settings/settings_screen.dart';
 
 class JobMarketScreen extends ConsumerWidget {
   const JobMarketScreen({super.key});
@@ -21,11 +23,30 @@ class JobMarketScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final allCavivaras = ref.watch(cavivaraDirectoryProvider);
     final employmentState = ref.watch(employmentStateProvider);
+    final defaultCavivaraId = employmentState.isNotEmpty
+        ? employmentState.first
+        : HomeScreen.defaultCavivaraId;
 
     return Scaffold(
       appBar: AppBar(
         title: const Text('転職市場'),
         centerTitle: true,
+      ),
+      drawer: AppDrawer(
+        isTalkSelected: false,
+        isJobMarketSelected: true,
+        onSelectTalk: () {
+          Navigator.of(context).pushAndRemoveUntil(
+            HomeScreen.route(defaultCavivaraId),
+            (route) => false,
+          );
+        },
+        onSelectJobMarket: () {
+          Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
+        },
+        onSelectSettings: () {
+          Navigator.of(context).push(SettingsScreen.route());
+        },
       ),
       body: ListView(
         padding: EdgeInsets.only(
@@ -156,6 +177,9 @@ class _CavivaraListItem extends StatelessWidget {
 
   /// チャット画面に遷移
   void _navigateToChat(BuildContext context) {
-    Navigator.of(context).push(HomeScreen.route(cavivaraId));
+    Navigator.of(context).pushAndRemoveUntil(
+      HomeScreen.route(cavivaraId),
+      (route) => false,
+    );
   }
 }

--- a/client/lib/ui/feature/job_market/job_market_screen.dart
+++ b/client/lib/ui/feature/job_market/job_market_screen.dart
@@ -42,7 +42,10 @@ class JobMarketScreen extends ConsumerWidget {
           );
         },
         onSelectJobMarket: () {
-          Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
+          Navigator.of(context).pushAndRemoveUntil(
+            JobMarketScreen.route(),
+            (route) => false,
+          );
         },
         onSelectSettings: () {
           Navigator.of(context).push(SettingsScreen.route());

--- a/client/lib/ui/feature/resume/resume_screen.dart
+++ b/client/lib/ui/feature/resume/resume_screen.dart
@@ -204,7 +204,10 @@ class ResumeScreen extends ConsumerWidget {
     EmploymentState employmentStateNotifier,
   ) {
     employmentStateNotifier.hire(cavivaraId);
-    Navigator.of(context).pushReplacement(HomeScreen.route(cavivaraId));
+    Navigator.of(context).pushAndRemoveUntil(
+      HomeScreen.route(cavivaraId),
+      (route) => false,
+    );
   }
 
   /// 解雇して転職市場画面に戻る
@@ -213,11 +216,17 @@ class ResumeScreen extends ConsumerWidget {
     EmploymentState employmentStateNotifier,
   ) {
     employmentStateNotifier.fire(cavivaraId);
-    Navigator.of(context).pushReplacement(JobMarketScreen.route());
+    Navigator.of(context).pushAndRemoveUntil(
+      JobMarketScreen.route(),
+      (route) => false,
+    );
   }
 
   /// チャット画面に遷移
   void _navigateToChat(BuildContext context) {
-    Navigator.of(context).pushReplacement(HomeScreen.route(cavivaraId));
+    Navigator.of(context).pushAndRemoveUntil(
+      HomeScreen.route(cavivaraId),
+      (route) => false,
+    );
   }
 }

--- a/client/lib/ui/root_app.dart
+++ b/client/lib/ui/root_app.dart
@@ -55,7 +55,7 @@ class _RootAppState extends ConsumerState<RootApp> {
       case AppInitialRoute.login:
         initialRoutes = [LoginScreen.route()];
       case AppInitialRoute.home:
-        initialRoutes = [HomeScreen.route('cavivara_default')];
+        initialRoutes = [HomeScreen.route(HomeScreen.defaultCavivaraId)];
       case AppInitialRoute.jobMarket:
         initialRoutes = [JobMarketScreen.route()];
     }


### PR DESCRIPTION
## Summary
- add a shared drawer widget that exposes Talk, Job Market, and Settings entries
- wire the drawer into the talk and job market screens to open it from the app bar menu button
- ensure navigating to talk or job market resets the stack while settings is pushed on top

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68ce490f17c88327b530b55c21dbac02