### PR TITLE
fix: カヴィヴァラの雇用状態を永続化するように修正

### DIFF
--- a/client/lib/data/model/preference_key.dart
+++ b/client/lib/data/model/preference_key.dart
@@ -1,1 +1,4 @@
-enum PreferenceKey { currentHouseId }
+enum PreferenceKey {
+  currentHouseId,
+  employedCavivaraIds,
+}

--- a/client/lib/data/service/employment_state_service.dart
+++ b/client/lib/data/service/employment_state_service.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:house_worker/data/model/preference_key.dart';
+import 'package:house_worker/data/service/preference_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'employment_state_service.g.dart';
@@ -6,26 +8,45 @@ part 'employment_state_service.g.dart';
 /// カヴィヴァラの雇用状態を管理するサービス
 ///
 /// 雇用状態は以下の特徴を持つ：
-/// - アプリ起動時はすべてのカヴィヴァラが未雇用状態で開始
-/// - 永続化は行わない（アプリ再起動で状態がリセットされる）
+/// - 永続化された値を読み込んで初期化する
+/// - 永続化データが存在しない場合は `cavivara_default` を雇用状態とする
 /// - 複数のカヴィヴァラを同時に雇用可能
 @riverpod
 class EmploymentState extends _$EmploymentState {
+  static const _defaultCavivaraId = 'cavivara_default';
+  static const _defaultEmployedState = <String>{_defaultCavivaraId};
+
+  Future<void>? _initialization;
+
   @override
   Set<String> build() {
-    // 初期状態：全員未雇用
-    // 永続化は不要（アプリ再起動時にリセットされる設計）
-    return const <String>{};
+    _initialization = _restoreState();
+    return _defaultEmployedState;
+  }
+
+  PreferenceService get _preferenceService =>
+      ref.read(preferenceServiceProvider);
+
+  /// 永続化された状態の読み込みが完了するまで待機する
+  Future<void> ensureInitialized() async {
+    final initialization = _initialization;
+    if (initialization != null) {
+      await initialization;
+    }
   }
 
   /// 指定されたカヴィヴァラを雇用する
-  void hire(String cavivaraId) {
+  Future<void> hire(String cavivaraId) async {
+    await ensureInitialized();
     state = {...state, cavivaraId};
+    await _persistState();
   }
 
   /// 指定されたカヴィヴァラを解雇する
-  void fire(String cavivaraId) {
+  Future<void> fire(String cavivaraId) async {
+    await ensureInitialized();
     state = state.where((id) => id != cavivaraId).toSet();
+    await _persistState();
   }
 
   /// 指定されたカヴィヴァラが雇用されているかどうか
@@ -37,8 +58,30 @@ class EmploymentState extends _$EmploymentState {
   List<String> get employedCavivaraIds => state.toList();
 
   /// 全員を解雇する
-  void fireAll() {
+  Future<void> fireAll() async {
+    await ensureInitialized();
     state = const <String>{};
+    await _persistState();
+  }
+
+  Future<void> _restoreState() async {
+    final storedIds = await _preferenceService
+        .getStringList(PreferenceKey.employedCavivaraIds);
+
+    if (storedIds == null) {
+      state = _defaultEmployedState;
+      await _persistState();
+      return;
+    }
+
+    state = storedIds.toSet();
+  }
+
+  Future<void> _persistState() async {
+    await _preferenceService.setStringList(
+      PreferenceKey.employedCavivaraIds,
+      value: state.toList(),
+    );
   }
 }
 

--- a/client/lib/data/service/preference_service.dart
+++ b/client/lib/data/service/preference_service.dart
@@ -20,4 +20,17 @@ class PreferenceService {
     final preferences = SharedPreferencesAsync();
     await preferences.setString(key.name, value);
   }
+
+  Future<List<String>?> getStringList(PreferenceKey key) {
+    final preferences = SharedPreferencesAsync();
+    return preferences.getStringList(key.name);
+  }
+
+  Future<void> setStringList(
+    PreferenceKey key, {
+    required List<String> value,
+  }) async {
+    final preferences = SharedPreferencesAsync();
+    await preferences.setStringList(key.name, value);
+  }
 }

--- a/client/lib/ui/feature/resume/resume_screen.dart
+++ b/client/lib/ui/feature/resume/resume_screen.dart
@@ -208,10 +208,12 @@ class ResumeScreen extends ConsumerWidget {
     EmploymentState employmentStateNotifier,
   ) async {
     await employmentStateNotifier.hire(cavivaraId);
-    Navigator.of(context).pushAndRemoveUntil(
-      HomeScreen.route(cavivaraId),
-      (route) => false,
-    );
+    if (context.mounted) {
+      await Navigator.of(context).pushAndRemoveUntil(
+        HomeScreen.route(cavivaraId),
+        (route) => false,
+      );
+    }
   }
 
   /// 解雇して転職市場画面に戻る
@@ -220,10 +222,12 @@ class ResumeScreen extends ConsumerWidget {
     EmploymentState employmentStateNotifier,
   ) async {
     await employmentStateNotifier.fire(cavivaraId);
-    Navigator.of(context).pushAndRemoveUntil(
-      JobMarketScreen.route(),
-      (route) => false,
-    );
+    if (context.mounted) {
+      await Navigator.of(context).pushAndRemoveUntil(
+        JobMarketScreen.route(),
+        (route) => false,
+      );
+    }
   }
 
   /// チャット画面に遷移

--- a/client/lib/ui/feature/resume/resume_screen.dart
+++ b/client/lib/ui/feature/resume/resume_screen.dart
@@ -6,7 +6,7 @@ import 'package:house_worker/ui/component/cavivara_avatar.dart';
 import 'package:house_worker/ui/feature/home/home_screen.dart';
 import 'package:house_worker/ui/feature/job_market/job_market_screen.dart';
 
-class ResumeScreen extends ConsumerWidget {
+class ResumeScreen extends ConsumerStatefulWidget {
   const ResumeScreen({super.key, required this.cavivaraId});
 
   /// 表示対象のカヴィヴァラID
@@ -21,10 +21,15 @@ class ResumeScreen extends ConsumerWidget {
       );
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ResumeScreen> createState() => _ResumeScreenState();
+}
+
+class _ResumeScreenState extends ConsumerState<ResumeScreen> {
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final cavivaraProfile = ref.watch(cavivaraByIdProvider(cavivaraId));
-    final isEmployed = ref.watch(isEmployedProvider(cavivaraId));
+    final cavivaraProfile = ref.watch(cavivaraByIdProvider(widget.cavivaraId));
+    final isEmployed = ref.watch(isEmployedProvider(widget.cavivaraId));
     final employmentStateNotifier = ref.read(employmentStateProvider.notifier);
 
     Widget sectionTitle(String text) {
@@ -89,7 +94,7 @@ class ResumeScreen extends ConsumerWidget {
                             CavivaraAvatar(
                               size: 96,
                               assetPath: cavivaraProfile.iconPath,
-                              cavivaraId: cavivaraId,
+                              cavivaraId: widget.cavivaraId,
                             ),
                             const SizedBox(width: 16),
                             Expanded(
@@ -207,10 +212,10 @@ class ResumeScreen extends ConsumerWidget {
     BuildContext context,
     EmploymentState employmentStateNotifier,
   ) async {
-    await employmentStateNotifier.hire(cavivaraId);
+    await employmentStateNotifier.hire(widget.cavivaraId);
     if (context.mounted) {
       await Navigator.of(context).pushAndRemoveUntil(
-        HomeScreen.route(cavivaraId),
+        HomeScreen.route(widget.cavivaraId),
         (route) => false,
       );
     }
@@ -221,7 +226,7 @@ class ResumeScreen extends ConsumerWidget {
     BuildContext context,
     EmploymentState employmentStateNotifier,
   ) async {
-    await employmentStateNotifier.fire(cavivaraId);
+    await employmentStateNotifier.fire(widget.cavivaraId);
     if (context.mounted) {
       await Navigator.of(context).pushAndRemoveUntil(
         JobMarketScreen.route(),
@@ -233,7 +238,7 @@ class ResumeScreen extends ConsumerWidget {
   /// チャット画面に遷移
   void _navigateToChat(BuildContext context) {
     Navigator.of(context).pushAndRemoveUntil(
-      HomeScreen.route(cavivaraId),
+      HomeScreen.route(widget.cavivaraId),
       (route) => false,
     );
   }

--- a/client/lib/ui/feature/resume/resume_screen.dart
+++ b/client/lib/ui/feature/resume/resume_screen.dart
@@ -163,10 +163,12 @@ class ResumeScreen extends ConsumerWidget {
               children: [
                 if (isEmployed) ...[
                   ElevatedButton.icon(
-                    onPressed: () => _fireAndNavigateToJobMarket(
-                      context,
-                      employmentStateNotifier,
-                    ),
+                    onPressed: () async {
+                      await _fireAndNavigateToJobMarket(
+                        context,
+                        employmentStateNotifier,
+                      );
+                    },
                     icon: const Icon(Icons.work_off),
                     label: const Text('解雇する'),
                     style: ElevatedButton.styleFrom(
@@ -182,10 +184,12 @@ class ResumeScreen extends ConsumerWidget {
                   ),
                 ] else ...[
                   ElevatedButton.icon(
-                    onPressed: () => _hireAndNavigateToChat(
-                      context,
-                      employmentStateNotifier,
-                    ),
+                    onPressed: () async {
+                      await _hireAndNavigateToChat(
+                        context,
+                        employmentStateNotifier,
+                      );
+                    },
                     icon: const Icon(Icons.work),
                     label: const Text('雇用する'),
                   ),
@@ -199,11 +203,11 @@ class ResumeScreen extends ConsumerWidget {
   }
 
   /// 雇用してチャット画面に遷移
-  void _hireAndNavigateToChat(
+  Future<void> _hireAndNavigateToChat(
     BuildContext context,
     EmploymentState employmentStateNotifier,
-  ) {
-    employmentStateNotifier.hire(cavivaraId);
+  ) async {
+    await employmentStateNotifier.hire(cavivaraId);
     Navigator.of(context).pushAndRemoveUntil(
       HomeScreen.route(cavivaraId),
       (route) => false,
@@ -211,11 +215,11 @@ class ResumeScreen extends ConsumerWidget {
   }
 
   /// 解雇して転職市場画面に戻る
-  void _fireAndNavigateToJobMarket(
+  Future<void> _fireAndNavigateToJobMarket(
     BuildContext context,
     EmploymentState employmentStateNotifier,
-  ) {
-    employmentStateNotifier.fire(cavivaraId);
+  ) async {
+    await employmentStateNotifier.fire(cavivaraId);
     Navigator.of(context).pushAndRemoveUntil(
       JobMarketScreen.route(),
       (route) => false,

--- a/client/lib/ui/feature/resume/resume_screen.dart
+++ b/client/lib/ui/feature/resume/resume_screen.dart
@@ -210,12 +210,14 @@ class _ResumeScreenState extends ConsumerState<ResumeScreen> {
     EmploymentState employmentStateNotifier,
   ) async {
     await employmentStateNotifier.hire(widget.cavivaraId);
-    if (mounted) {
-      await Navigator.of(context).pushAndRemoveUntil(
-        HomeScreen.route(widget.cavivaraId),
-        (route) => false,
-      );
+    if (!mounted) {
+      return;
     }
+
+    await Navigator.of(context).pushAndRemoveUntil(
+      HomeScreen.route(widget.cavivaraId),
+      (route) => false,
+    );
   }
 
   /// 解雇して転職市場画面に戻る
@@ -223,12 +225,14 @@ class _ResumeScreenState extends ConsumerState<ResumeScreen> {
     EmploymentState employmentStateNotifier,
   ) async {
     await employmentStateNotifier.fire(widget.cavivaraId);
-    if (mounted) {
-      await Navigator.of(context).pushAndRemoveUntil(
-        JobMarketScreen.route(),
-        (route) => false,
-      );
+    if (!mounted) {
+      return;
     }
+
+    await Navigator.of(context).pushAndRemoveUntil(
+      JobMarketScreen.route(),
+      (route) => false,
+    );
   }
 
   /// チャット画面に遷移

--- a/client/lib/ui/feature/resume/resume_screen.dart
+++ b/client/lib/ui/feature/resume/resume_screen.dart
@@ -170,7 +170,6 @@ class _ResumeScreenState extends ConsumerState<ResumeScreen> {
                   ElevatedButton.icon(
                     onPressed: () async {
                       await _fireAndNavigateToJobMarket(
-                        context,
                         employmentStateNotifier,
                       );
                     },
@@ -183,7 +182,7 @@ class _ResumeScreenState extends ConsumerState<ResumeScreen> {
                   ),
                   const SizedBox(height: 8),
                   OutlinedButton.icon(
-                    onPressed: () => _navigateToChat(context),
+                    onPressed: _navigateToChat,
                     icon: const Icon(Icons.chat),
                     label: const Text('相談する'),
                   ),
@@ -191,7 +190,6 @@ class _ResumeScreenState extends ConsumerState<ResumeScreen> {
                   ElevatedButton.icon(
                     onPressed: () async {
                       await _hireAndNavigateToChat(
-                        context,
                         employmentStateNotifier,
                       );
                     },
@@ -209,11 +207,10 @@ class _ResumeScreenState extends ConsumerState<ResumeScreen> {
 
   /// 雇用してチャット画面に遷移
   Future<void> _hireAndNavigateToChat(
-    BuildContext context,
     EmploymentState employmentStateNotifier,
   ) async {
     await employmentStateNotifier.hire(widget.cavivaraId);
-    if (context.mounted) {
+    if (mounted) {
       await Navigator.of(context).pushAndRemoveUntil(
         HomeScreen.route(widget.cavivaraId),
         (route) => false,
@@ -223,11 +220,10 @@ class _ResumeScreenState extends ConsumerState<ResumeScreen> {
 
   /// 解雇して転職市場画面に戻る
   Future<void> _fireAndNavigateToJobMarket(
-    BuildContext context,
     EmploymentState employmentStateNotifier,
   ) async {
     await employmentStateNotifier.fire(widget.cavivaraId);
-    if (context.mounted) {
+    if (mounted) {
       await Navigator.of(context).pushAndRemoveUntil(
         JobMarketScreen.route(),
         (route) => false,
@@ -236,7 +232,7 @@ class _ResumeScreenState extends ConsumerState<ResumeScreen> {
   }
 
   /// チャット画面に遷移
-  void _navigateToChat(BuildContext context) {
+  void _navigateToChat() {
     Navigator.of(context).pushAndRemoveUntil(
       HomeScreen.route(widget.cavivaraId),
       (route) => false,

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -1073,7 +1073,7 @@ packages:
     source: hosted
     version: "2.4.1"
   shared_preferences_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: shared_preferences_platform_interface
       sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -46,6 +46,7 @@ dev_dependencies:
   pedantic_mono: ^1.33.0
   riverpod_generator: ^2.6.5
   riverpod_lint: ^2.6.5
+  shared_preferences_platform_interface: ^2.0.0
 
 flutter:
   uses-material-design: true

--- a/client/test/data/service/employment_state_service_test.dart
+++ b/client/test/data/service/employment_state_service_test.dart
@@ -1,12 +1,15 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:house_worker/data/model/preference_key.dart';
 import 'package:house_worker/data/service/employment_state_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   group('EmploymentStateService', () {
     late ProviderContainer container;
 
     setUp(() {
+      SharedPreferences.setMockInitialValues({});
       container = ProviderContainer();
     });
 
@@ -14,73 +17,132 @@ void main() {
       container.dispose();
     });
 
+    EmploymentState get notifier =>
+        container.read(employmentStateProvider.notifier);
+
+    Future<void> waitForInitialization() => notifier.ensureInitialized();
+
     group('初期状態', () {
-      test('初期状態では全員が未雇用であること', () {
+      test('永続化データがない場合はデフォルトカヴィヴァラのみ雇用されていること', () async {
+        await waitForInitialization();
+
         final state = container.read(employmentStateProvider);
-        expect(state, isEmpty);
+        expect(state, equals({'cavivara_default'}));
       });
 
-      test('初期状態では特定のキャラクターが未雇用であること', () {
-        const cavivaraId = 'cavivara_default';
-        final isEmployed = container.read(isEmployedProvider(cavivaraId));
-        expect(isEmployed, isFalse);
+      test('永続化データが存在する場合は永続化された値で初期化されること', () async {
+        container.dispose();
+        SharedPreferences.setMockInitialValues({
+          PreferenceKey.employedCavivaraIds.name: <String>['cavivara_mascot'],
+        });
+        container = ProviderContainer();
+
+        await container
+            .read(employmentStateProvider.notifier)
+            .ensureInitialized();
+
+        final state = container.read(employmentStateProvider);
+        expect(state, equals({'cavivara_mascot'}));
       });
 
-      test('初期状態では雇用中のリストが空であること', () {
+      test('初期化後はデフォルトカヴィヴァラが雇用済みとして判定されること', () async {
+        await waitForInitialization();
+
+        expect(
+          container.read(isEmployedProvider('cavivara_default')),
+          isTrue,
+        );
+      });
+
+      test('雇用中のカヴィヴァラIDリストにデフォルトが含まれること', () async {
+        await waitForInitialization();
+
         final employedIds = container.read(employedCavivaraIdsProvider);
-        expect(employedIds, isEmpty);
+        expect(employedIds, contains('cavivara_default'));
+      });
+    });
+
+    group('永続化', () {
+      test('雇用状態の変更が永続化されること', () async {
+        await waitForInitialization();
+        await notifier.hire('cavivara_mascot');
+
+        final newContainer = ProviderContainer();
+        addTearDown(newContainer.dispose);
+        await newContainer
+            .read(employmentStateProvider.notifier)
+            .ensureInitialized();
+
+        final state = newContainer.read(employmentStateProvider);
+        expect(state, containsAll({'cavivara_default', 'cavivara_mascot'}));
+      });
+
+      test('全員解雇後の状態が永続化されること', () async {
+        await waitForInitialization();
+        await notifier.fireAll();
+
+        final newContainer = ProviderContainer();
+        addTearDown(newContainer.dispose);
+        await newContainer
+            .read(employmentStateProvider.notifier)
+            .ensureInitialized();
+
+        expect(newContainer.read(employmentStateProvider), isEmpty);
       });
     });
 
     group('雇用処理', () {
-      test('カヴィヴァラを雇用できること', () {
-        const cavivaraId = 'cavivara_default';
-        container.read(employmentStateProvider.notifier).hire(cavivaraId);
+      test('新しいカヴィヴァラを雇用できること', () async {
+        await waitForInitialization();
+        const cavivaraId = 'cavivara_mascot';
+
+        await notifier.hire(cavivaraId);
 
         final state = container.read(employmentStateProvider);
         final isEmployed = container.read(isEmployedProvider(cavivaraId));
 
-        expect(state, contains(cavivaraId));
+        expect(state, containsAll({'cavivara_default', cavivaraId}));
         expect(isEmployed, isTrue);
       });
 
-      test('複数のカヴィヴァラを同時に雇用できること', () {
+      test('複数のカヴィヴァラを同時に雇用できること', () async {
+        await waitForInitialization();
         const cavivaraId1 = 'cavivara_default';
         const cavivaraId2 = 'cavivara_mascot';
-        container.read(employmentStateProvider.notifier)
-          ..hire(cavivaraId1)
-          ..hire(cavivaraId2);
+
+        await notifier.fireAll();
+        await notifier.hire(cavivaraId1);
+        await notifier.hire(cavivaraId2);
 
         final state = container.read(employmentStateProvider);
         final isEmployed1 = container.read(isEmployedProvider(cavivaraId1));
         final isEmployed2 = container.read(isEmployedProvider(cavivaraId2));
 
-        expect(state, containsAll([cavivaraId1, cavivaraId2]));
+        expect(state, containsAll({cavivaraId1, cavivaraId2}));
         expect(isEmployed1, isTrue);
         expect(isEmployed2, isTrue);
       });
 
-      test('同じカヴィヴァラを重複して雇用しても状態が変わらないこと', () {
-        const cavivaraId = 'cavivara_default';
-        container.read(employmentStateProvider.notifier)
-          ..hire(cavivaraId)
-          ..hire(cavivaraId); // 重複雇用
+      test('同じカヴィヴァラを重複して雇用しても状態が変わらないこと', () async {
+        await waitForInitialization();
+        const cavivaraId = 'cavivara_mascot';
+
+        await notifier.fireAll();
+        await notifier.hire(cavivaraId);
+        await notifier.hire(cavivaraId); // 重複雇用
 
         final state = container.read(employmentStateProvider);
-        expect(state, hasLength(1));
-        expect(state, contains(cavivaraId));
+        expect(state.where((id) => id == cavivaraId), hasLength(1));
       });
     });
 
     group('解雇処理', () {
-      test('雇用中のカヴィヴァラを解雇できること', () {
+      test('雇用中のカヴィヴァラを解雇できること', () async {
+        await waitForInitialization();
         const cavivaraId = 'cavivara_default';
-        final notifier = container.read(employmentStateProvider.notifier)
-          ..hire(cavivaraId);
         expect(container.read(isEmployedProvider(cavivaraId)), isTrue);
 
-        // 解雇
-        notifier.fire(cavivaraId);
+        await notifier.fire(cavivaraId);
 
         final state = container.read(employmentStateProvider);
         final isEmployed = container.read(isEmployedProvider(cavivaraId));
@@ -89,21 +151,23 @@ void main() {
         expect(isEmployed, isFalse);
       });
 
-      test('未雇用のカヴィヴァラを解雇しても状態が変わらないこと', () {
-        const cavivaraId = 'cavivara_default';
-        container.read(employmentStateProvider.notifier).fire(cavivaraId);
+      test('未雇用のカヴィヴァラを解雇しても状態が変わらないこと', () async {
+        await waitForInitialization();
+        const cavivaraId = 'cavivara_mascot';
+
+        await notifier.fire(cavivaraId);
 
         final state = container.read(employmentStateProvider);
-        expect(state, isEmpty);
+        expect(state, equals({'cavivara_default'}));
       });
 
-      test('複数雇用時に特定のカヴィヴァラのみ解雇できること', () {
+      test('複数雇用時に特定のカヴィヴァラのみ解雇できること', () async {
+        await waitForInitialization();
         const cavivaraId1 = 'cavivara_default';
         const cavivaraId2 = 'cavivara_mascot';
-        container.read(employmentStateProvider.notifier)
-          ..hire(cavivaraId1)
-          ..hire(cavivaraId2)
-          ..fire(cavivaraId1);
+
+        await notifier.hire(cavivaraId2);
+        await notifier.fire(cavivaraId1);
 
         final state = container.read(employmentStateProvider);
         expect(state, isNot(contains(cavivaraId1)));
@@ -117,88 +181,83 @@ void main() {
     });
 
     group('全員解雇処理', () {
-      test('全員を解雇できること', () {
-        const cavivaraId1 = 'cavivara_default';
-        const cavivaraId2 = 'cavivara_mascot';
-        final notifier = container.read(employmentStateProvider.notifier)
-          ..hire(cavivaraId1)
-          ..hire(cavivaraId2);
+      test('全員を解雇できること', () async {
+        await waitForInitialization();
+        await notifier.hire('cavivara_mascot');
         expect(container.read(employmentStateProvider), hasLength(2));
 
-        // 全員解雇
-        notifier.fireAll();
+        await notifier.fireAll();
 
         final state = container.read(employmentStateProvider);
         expect(state, isEmpty);
 
-        final isEmployed1 = container.read(isEmployedProvider(cavivaraId1));
-        final isEmployed2 = container.read(isEmployedProvider(cavivaraId2));
+        final isEmployed1 = container.read(isEmployedProvider('cavivara_default'));
+        final isEmployed2 = container.read(isEmployedProvider('cavivara_mascot'));
         expect(isEmployed1, isFalse);
         expect(isEmployed2, isFalse);
       });
 
-      test('全員未雇用状態で全員解雇しても状態が変わらないこと', () {
-        container.read(employmentStateProvider.notifier).fireAll();
+      test('全員未雇用状態で全員解雇しても状態が変わらないこと', () async {
+        await waitForInitialization();
+        await notifier.fireAll();
 
-        final state = container.read(employmentStateProvider);
-        expect(state, isEmpty);
+        final stateAfterFirst = container.read(employmentStateProvider);
+        expect(stateAfterFirst, isEmpty);
+
+        await notifier.fireAll();
+
+        final stateAfterSecond = container.read(employmentStateProvider);
+        expect(stateAfterSecond, isEmpty);
       });
     });
 
     group('雇用リスト取得', () {
-      test('雇用中のカヴィヴァラIDリストが正しく取得できること', () {
-        const cavivaraId1 = 'cavivara_default';
-        const cavivaraId2 = 'cavivara_mascot';
-        container.read(employmentStateProvider.notifier)
-          ..hire(cavivaraId1)
-          ..hire(cavivaraId2);
+      test('雇用中のカヴィヴァラIDリストが正しく取得できること', () async {
+        await waitForInitialization();
+        await notifier.hire('cavivara_mascot');
 
         final employedIds = container.read(employedCavivaraIdsProvider);
-        expect(employedIds, hasLength(2));
-        expect(employedIds, containsAll([cavivaraId1, cavivaraId2]));
+        expect(employedIds, containsAll(['cavivara_default', 'cavivara_mascot']));
       });
 
-      test('雇用状態の変化がリアルタイムで反映されること', () {
-        const cavivaraId = 'cavivara_default';
-        final notifier = container.read(employmentStateProvider.notifier);
+      test('雇用状態の変化がリアルタイムで反映されること', () async {
+        await waitForInitialization();
+        const cavivaraId = 'cavivara_mascot';
 
-        // 雇用前
         var employedIds = container.read(employedCavivaraIdsProvider);
-        expect(employedIds, isEmpty);
+        expect(employedIds, contains('cavivara_default'));
+        expect(employedIds, isNot(contains(cavivaraId)));
 
-        // 雇用後
-        notifier.hire(cavivaraId);
+        await notifier.hire(cavivaraId);
         employedIds = container.read(employedCavivaraIdsProvider);
         expect(employedIds, contains(cavivaraId));
 
-        // 解雇後
-        notifier.fire(cavivaraId);
+        await notifier.fire(cavivaraId);
         employedIds = container.read(employedCavivaraIdsProvider);
-        expect(employedIds, isEmpty);
+        expect(employedIds, isNot(contains(cavivaraId)));
       });
     });
 
     group('状態通知', () {
-      test('雇用状態の変化でプロバイダーが通知されること', () {
-        const cavivaraId = 'cavivara_default';
-        final notifier = container.read(employmentStateProvider.notifier);
+      test('雇用状態の変化でプロバイダーが通知されること', () async {
+        await waitForInitialization();
+        final employmentStateNotifier = notifier;
         var notificationCount = 0;
 
-        // リスナーを追加
-        container.listen(
+        container.listen<Set<String>>(
           employmentStateProvider,
           (previous, next) {
             notificationCount++;
           },
         );
 
-        notifier.hire(cavivaraId);
+        await employmentStateNotifier.hire('cavivara_mascot');
         expect(notificationCount, equals(1));
 
-        notifier.fire(cavivaraId);
+        await employmentStateNotifier.fire('cavivara_mascot');
         expect(notificationCount, equals(2));
 
-        notifier.fireAll();
+        await employmentStateNotifier.fireAll();
         expect(notificationCount, equals(3));
       });
     });

--- a/client/test/data/service/employment_state_service_test.dart
+++ b/client/test/data/service/employment_state_service_test.dart
@@ -17,10 +17,10 @@ void main() {
       container.dispose();
     });
 
-    EmploymentState get notifier =>
+    EmploymentState notifier() =>
         container.read(employmentStateProvider.notifier);
 
-    Future<void> waitForInitialization() => notifier.ensureInitialized();
+    Future<void> waitForInitialization() => notifier().ensureInitialized();
 
     group('初期状態', () {
       test('永続化データがない場合はデフォルトカヴィヴァラのみ雇用されていること', () async {
@@ -65,7 +65,7 @@ void main() {
     group('永続化', () {
       test('雇用状態の変更が永続化されること', () async {
         await waitForInitialization();
-        await notifier.hire('cavivara_mascot');
+        await notifier().hire('cavivara_mascot');
 
         final newContainer = ProviderContainer();
         addTearDown(newContainer.dispose);
@@ -79,7 +79,7 @@ void main() {
 
       test('全員解雇後の状態が永続化されること', () async {
         await waitForInitialization();
-        await notifier.fireAll();
+        await notifier().fireAll();
 
         final newContainer = ProviderContainer();
         addTearDown(newContainer.dispose);
@@ -96,7 +96,7 @@ void main() {
         await waitForInitialization();
         const cavivaraId = 'cavivara_mascot';
 
-        await notifier.hire(cavivaraId);
+        await notifier().hire(cavivaraId);
 
         final state = container.read(employmentStateProvider);
         final isEmployed = container.read(isEmployedProvider(cavivaraId));
@@ -110,9 +110,9 @@ void main() {
         const cavivaraId1 = 'cavivara_default';
         const cavivaraId2 = 'cavivara_mascot';
 
-        await notifier.fireAll();
-        await notifier.hire(cavivaraId1);
-        await notifier.hire(cavivaraId2);
+        await notifier().fireAll();
+        await notifier().hire(cavivaraId1);
+        await notifier().hire(cavivaraId2);
 
         final state = container.read(employmentStateProvider);
         final isEmployed1 = container.read(isEmployedProvider(cavivaraId1));
@@ -127,9 +127,9 @@ void main() {
         await waitForInitialization();
         const cavivaraId = 'cavivara_mascot';
 
-        await notifier.fireAll();
-        await notifier.hire(cavivaraId);
-        await notifier.hire(cavivaraId); // 重複雇用
+        await notifier().fireAll();
+        await notifier().hire(cavivaraId);
+        await notifier().hire(cavivaraId); // 重複雇用
 
         final state = container.read(employmentStateProvider);
         expect(state.where((id) => id == cavivaraId), hasLength(1));
@@ -142,7 +142,7 @@ void main() {
         const cavivaraId = 'cavivara_default';
         expect(container.read(isEmployedProvider(cavivaraId)), isTrue);
 
-        await notifier.fire(cavivaraId);
+        await notifier().fire(cavivaraId);
 
         final state = container.read(employmentStateProvider);
         final isEmployed = container.read(isEmployedProvider(cavivaraId));
@@ -155,7 +155,7 @@ void main() {
         await waitForInitialization();
         const cavivaraId = 'cavivara_mascot';
 
-        await notifier.fire(cavivaraId);
+        await notifier().fire(cavivaraId);
 
         final state = container.read(employmentStateProvider);
         expect(state, equals({'cavivara_default'}));
@@ -166,8 +166,8 @@ void main() {
         const cavivaraId1 = 'cavivara_default';
         const cavivaraId2 = 'cavivara_mascot';
 
-        await notifier.hire(cavivaraId2);
-        await notifier.fire(cavivaraId1);
+        await notifier().hire(cavivaraId2);
+        await notifier().fire(cavivaraId1);
 
         final state = container.read(employmentStateProvider);
         expect(state, isNot(contains(cavivaraId1)));
@@ -183,28 +183,32 @@ void main() {
     group('全員解雇処理', () {
       test('全員を解雇できること', () async {
         await waitForInitialization();
-        await notifier.hire('cavivara_mascot');
+        await notifier().hire('cavivara_mascot');
         expect(container.read(employmentStateProvider), hasLength(2));
 
-        await notifier.fireAll();
+        await notifier().fireAll();
 
         final state = container.read(employmentStateProvider);
         expect(state, isEmpty);
 
-        final isEmployed1 = container.read(isEmployedProvider('cavivara_default'));
-        final isEmployed2 = container.read(isEmployedProvider('cavivara_mascot'));
+        final isEmployed1 = container.read(
+          isEmployedProvider('cavivara_default'),
+        );
+        final isEmployed2 = container.read(
+          isEmployedProvider('cavivara_mascot'),
+        );
         expect(isEmployed1, isFalse);
         expect(isEmployed2, isFalse);
       });
 
       test('全員未雇用状態で全員解雇しても状態が変わらないこと', () async {
         await waitForInitialization();
-        await notifier.fireAll();
+        await notifier().fireAll();
 
         final stateAfterFirst = container.read(employmentStateProvider);
         expect(stateAfterFirst, isEmpty);
 
-        await notifier.fireAll();
+        await notifier().fireAll();
 
         final stateAfterSecond = container.read(employmentStateProvider);
         expect(stateAfterSecond, isEmpty);
@@ -214,10 +218,13 @@ void main() {
     group('雇用リスト取得', () {
       test('雇用中のカヴィヴァラIDリストが正しく取得できること', () async {
         await waitForInitialization();
-        await notifier.hire('cavivara_mascot');
+        await notifier().hire('cavivara_mascot');
 
         final employedIds = container.read(employedCavivaraIdsProvider);
-        expect(employedIds, containsAll(['cavivara_default', 'cavivara_mascot']));
+        expect(
+          employedIds,
+          containsAll(['cavivara_default', 'cavivara_mascot']),
+        );
       });
 
       test('雇用状態の変化がリアルタイムで反映されること', () async {
@@ -228,11 +235,11 @@ void main() {
         expect(employedIds, contains('cavivara_default'));
         expect(employedIds, isNot(contains(cavivaraId)));
 
-        await notifier.hire(cavivaraId);
+        await notifier().hire(cavivaraId);
         employedIds = container.read(employedCavivaraIdsProvider);
         expect(employedIds, contains(cavivaraId));
 
-        await notifier.fire(cavivaraId);
+        await notifier().fire(cavivaraId);
         employedIds = container.read(employedCavivaraIdsProvider);
         expect(employedIds, isNot(contains(cavivaraId)));
       });
@@ -241,7 +248,7 @@ void main() {
     group('状態通知', () {
       test('雇用状態の変化でプロバイダーが通知されること', () async {
         await waitForInitialization();
-        final employmentStateNotifier = notifier;
+        final employmentStateNotifier = notifier();
         var notificationCount = 0;
 
         container.listen<Set<String>>(

--- a/client/test/data/service/employment_state_service_test.dart
+++ b/client/test/data/service/employment_state_service_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:house_worker/data/model/preference_key.dart';
 import 'package:house_worker/data/service/employment_state_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
 
 void main() {
   group('EmploymentStateService', () {
@@ -10,6 +12,8 @@ void main() {
 
     setUp(() {
       SharedPreferences.setMockInitialValues({});
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
       container = ProviderContainer();
     });
 
@@ -33,6 +37,10 @@ void main() {
       test('永続化データが存在する場合は永続化された値で初期化されること', () async {
         container.dispose();
         SharedPreferences.setMockInitialValues({
+          PreferenceKey.employedCavivaraIds.name: <String>['cavivara_mascot'],
+        });
+        SharedPreferencesAsyncPlatform
+            .instance = InMemorySharedPreferencesAsync.withData({
           PreferenceKey.employedCavivaraIds.name: <String>['cavivara_mascot'],
         });
         container = ProviderContainer();

--- a/client/test/ui/feature/job_market/job_market_screen_test.dart
+++ b/client/test/ui/feature/job_market/job_market_screen_test.dart
@@ -1,11 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:house_worker/data/model/preference_key.dart';
 import 'package:house_worker/data/service/employment_state_service.dart';
 import 'package:house_worker/ui/feature/job_market/job_market_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   group('JobMarketScreen', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
     testWidgets('displays job market title', (WidgetTester tester) async {
       await tester.pumpWidget(
         const ProviderScope(
@@ -55,29 +61,14 @@ void main() {
     testWidgets(
       'shows employment badge for employed cavivara',
       (WidgetTester tester) async {
-        late ProviderContainer container;
         await tester.pumpWidget(
-          ProviderScope(
-            child: Builder(
-              builder: (context) {
-                container = ProviderScope.containerOf(context);
-                return const MaterialApp(
-                  home: JobMarketScreen(),
-                );
-              },
+          const ProviderScope(
+            child: MaterialApp(
+              home: JobMarketScreen(),
             ),
           ),
         );
 
-        await tester.pumpAndSettle();
-
-        // 初期状態では雇用中バッジが表示されないことを確認
-        expect(find.text('雇用中'), findsNothing);
-
-        // カヴィヴァラを雇用
-        container
-            .read(employmentStateProvider.notifier)
-            .hire('cavivara_default');
         await tester.pumpAndSettle();
 
         // 雇用中バッジが表示されることを確認
@@ -88,29 +79,14 @@ void main() {
     testWidgets(
       'shows consult button for employed cavivara',
       (WidgetTester tester) async {
-        late ProviderContainer container;
         await tester.pumpWidget(
-          ProviderScope(
-            child: Builder(
-              builder: (context) {
-                container = ProviderScope.containerOf(context);
-                return const MaterialApp(
-                  home: JobMarketScreen(),
-                );
-              },
+          const ProviderScope(
+            child: MaterialApp(
+              home: JobMarketScreen(),
             ),
           ),
         );
 
-        await tester.pumpAndSettle();
-
-        // 初期状態では相談ボタンが表示されないことを確認
-        expect(find.text('相談する'), findsNothing);
-
-        // カヴィヴァラを雇用
-        container
-            .read(employmentStateProvider.notifier)
-            .hire('cavivara_default');
         await tester.pumpAndSettle();
 
         // 相談ボタンが表示されることを確認
@@ -121,6 +97,9 @@ void main() {
     testWidgets(
       'employment state changes are reflected in real-time',
       (WidgetTester tester) async {
+        SharedPreferences.setMockInitialValues({
+          PreferenceKey.employedCavivaraIds.name: <String>[],
+        });
         late ProviderContainer container;
         await tester.pumpWidget(
           ProviderScope(
@@ -138,9 +117,12 @@ void main() {
         await tester.pumpAndSettle();
 
         // 複数のカヴィヴァラを雇用
-        container.read(employmentStateProvider.notifier)
-          ..hire('cavivara_default')
-          ..hire('cavivara_mascot');
+        await container
+            .read(employmentStateProvider.notifier)
+            .hire('cavivara_default');
+        await container
+            .read(employmentStateProvider.notifier)
+            .hire('cavivara_mascot');
         await tester.pumpAndSettle();
 
         // 両方の雇用中バッジが表示されることを確認
@@ -148,7 +130,7 @@ void main() {
         expect(find.text('相談する'), findsNWidgets(2));
 
         // 一人を解雇
-        container
+        await container
             .read(employmentStateProvider.notifier)
             .fire('cavivara_default');
         await tester.pumpAndSettle();

--- a/client/test/ui/feature/job_market/job_market_screen_test.dart
+++ b/client/test/ui/feature/job_market/job_market_screen_test.dart
@@ -5,11 +5,15 @@ import 'package:house_worker/data/model/preference_key.dart';
 import 'package:house_worker/data/service/employment_state_service.dart';
 import 'package:house_worker/ui/feature/job_market/job_market_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
 
 void main() {
   group('JobMarketScreen', () {
     setUp(() {
       SharedPreferences.setMockInitialValues({});
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
     });
 
     testWidgets('displays job market title', (WidgetTester tester) async {
@@ -100,6 +104,10 @@ void main() {
         SharedPreferences.setMockInitialValues({
           PreferenceKey.employedCavivaraIds.name: <String>[],
         });
+        SharedPreferencesAsyncPlatform.instance =
+            InMemorySharedPreferencesAsync.withData({
+              PreferenceKey.employedCavivaraIds.name: <String>[],
+            });
         late ProviderContainer container;
         await tester.pumpWidget(
           ProviderScope(

--- a/client/test/ui/feature/resume/resume_screen_test.dart
+++ b/client/test/ui/feature/resume/resume_screen_test.dart
@@ -5,6 +5,8 @@ import 'package:house_worker/data/model/preference_key.dart';
 import 'package:house_worker/data/service/employment_state_service.dart';
 import 'package:house_worker/ui/feature/resume/resume_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
 
 void main() {
   group('ResumeScreen', () {
@@ -12,6 +14,8 @@ void main() {
 
     setUp(() {
       SharedPreferences.setMockInitialValues({});
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
     });
 
     testWidgets(
@@ -38,6 +42,10 @@ void main() {
         SharedPreferences.setMockInitialValues({
           PreferenceKey.employedCavivaraIds.name: <String>[],
         });
+        SharedPreferencesAsyncPlatform.instance =
+            InMemorySharedPreferencesAsync.withData({
+              PreferenceKey.employedCavivaraIds.name: <String>[],
+            });
 
         await tester.pumpWidget(
           const ProviderScope(
@@ -82,6 +90,10 @@ void main() {
         SharedPreferences.setMockInitialValues({
           PreferenceKey.employedCavivaraIds.name: <String>[],
         });
+        SharedPreferencesAsyncPlatform.instance =
+            InMemorySharedPreferencesAsync.withData({
+              PreferenceKey.employedCavivaraIds.name: <String>[],
+            });
         late ProviderContainer container;
         await tester.pumpWidget(
           ProviderScope(


### PR DESCRIPTION
## Summary
- persist employment state via SharedPreferences and default to cavivara_default when no data exists
- extend PreferenceService with string list helpers for storing employed Cavivara IDs
- update resume UI and tests to handle async employment changes and new persisted defaults

## Testing
- `flutter test` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ce9efd68088327b3ad5f17ef5f3b0e