### PR TITLE
Open chat after install with anonymous sign-in

### DIFF
--- a/client/lib/ui/root_presenter.dart
+++ b/client/lib/ui/root_presenter.dart
@@ -8,6 +8,7 @@ import 'package:house_worker/data/service/auth_service.dart';
 import 'package:house_worker/data/service/preference_service.dart';
 import 'package:house_worker/data/service/remote_config_service.dart';
 import 'package:house_worker/ui/app_initial_route.dart';
+import 'package:house_worker/ui/feature/home/home_screen.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'root_presenter.g.dart';
@@ -33,17 +34,22 @@ Future<AppInitialRoute> appInitialRoute(Ref ref) async {
   final appSession = await appSessionFuture;
   switch (appSession) {
     case AppSessionSignedIn():
-      final lastTalkedCavivaraId = await ref.read(
-        lastTalkedCavivaraIdProvider.future,
-      );
-      if (lastTalkedCavivaraId != null) {
-        return AppInitialRoute.home(cavivaraId: lastTalkedCavivaraId);
-      }
-
-      return const AppInitialRoute.jobMarket();
+      final cavivaraId = await _resolveInitialCavivaraId(ref);
+      return AppInitialRoute.home(cavivaraId: cavivaraId);
     case AppSessionNotSignedIn():
-      return const AppInitialRoute.login();
+      await ref
+          .read(currentAppSessionProvider.notifier)
+          .ensureSignedInAnonymously();
+      final cavivaraId = await _resolveInitialCavivaraId(ref);
+      return AppInitialRoute.home(cavivaraId: cavivaraId);
   }
+}
+
+Future<String> _resolveInitialCavivaraId(Ref ref) async {
+  final lastTalkedCavivaraId = await ref.read(
+    lastTalkedCavivaraIdProvider.future,
+  );
+  return lastTalkedCavivaraId ?? HomeScreen.defaultCavivaraId;
 }
 
 @riverpod
@@ -55,17 +61,7 @@ class CurrentAppSession extends _$CurrentAppSession {
       return AppSession.notSignedIn();
     }
 
-    final preferenceService = ref.read(preferenceServiceProvider);
-
-    final houseId =
-        await preferenceService.getString(PreferenceKey.currentHouseId) ??
-        // TODO(ide): 開発用。本番リリース時には削除する
-        'default-house-id';
-
-    // TODO(ide): RevenueCatから取得する開発用。本番リリース時には削除する
-    const isPro = false;
-
-    return AppSession.signedIn(counterId: houseId, isPro: isPro);
+    return _createSignedInSession();
   }
 
   Future<void> signIn({required String userId, required String houseId}) async {
@@ -88,6 +84,38 @@ class CurrentAppSession extends _$CurrentAppSession {
       final newState = currentAppSession.copyWith(isPro: true);
       state = AsyncValue.data(newState);
     }
+  }
+
+  Future<AppSessionSignedIn> ensureSignedInAnonymously() async {
+    final currentAppSession = state.valueOrNull ?? await future;
+    if (currentAppSession case AppSessionSignedIn()) {
+      return currentAppSession;
+    }
+
+    final authService = ref.read(authServiceProvider);
+    await authService.signInAnonymously();
+
+    final newSession = await _createSignedInSession();
+    if (newSession case AppSessionSignedIn()) {
+      state = AsyncValue.data(newSession);
+      return newSession;
+    }
+
+    throw StateError('Failed to sign in anonymously.');
+  }
+
+  Future<AppSession> _createSignedInSession() async {
+    final preferenceService = ref.read(preferenceServiceProvider);
+
+    final houseId =
+        await preferenceService.getString(PreferenceKey.currentHouseId) ??
+        // TODO(ide): 開発用。本番リリース時には削除する
+        'default-house-id';
+
+    // TODO(ide): RevenueCatから取得する開発用。本番リリース時には削除する
+    const isPro = false;
+
+    return AppSession.signedIn(counterId: houseId, isPro: isPro);
   }
 }
 

--- a/client/test/ui/root_presenter_test.dart
+++ b/client/test/ui/root_presenter_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:house_worker/data/model/app_session.dart';
+import 'package:house_worker/data/model/app_version.dart';
+import 'package:house_worker/data/repository/last_talked_cavivara_id_repository.dart';
+import 'package:house_worker/data/service/app_info_service.dart';
+import 'package:house_worker/data/service/remote_config_service.dart';
+import 'package:house_worker/ui/app_initial_route.dart';
+import 'package:house_worker/ui/feature/home/home_screen.dart';
+import 'package:house_worker/ui/root_presenter.dart';
+
+class _FakeUpdatedRemoteConfigKeys extends UpdatedRemoteConfigKeys {
+  @override
+  Stream<Set<String>> build() => const Stream.empty();
+
+  @override
+  Future<void> ensureActivateFetchedRemoteConfigs() async {}
+}
+
+class _FakeCurrentAppSession extends CurrentAppSession {
+  _FakeCurrentAppSession({required this.initialSession});
+
+  final AppSession initialSession;
+  var ensureCalled = false;
+
+  @override
+  Future<AppSession> build() async => initialSession;
+
+  @override
+  Future<AppSessionSignedIn> ensureSignedInAnonymously() async {
+    ensureCalled = true;
+    final session = AppSession.signedIn(
+      counterId: 'fake-house-id',
+      isPro: false,
+    );
+    state = AsyncValue.data(session);
+    return session as AppSessionSignedIn;
+  }
+}
+
+class _FakeLastTalkedCavivaraId extends LastTalkedCavivaraId {
+  _FakeLastTalkedCavivaraId(this.initialId);
+
+  final String? initialId;
+
+  @override
+  Future<String?> build() async => initialId;
+}
+
+ProviderContainer _createContainer({
+  required _FakeCurrentAppSession currentAppSession,
+  required _FakeLastTalkedCavivaraId lastTalked,
+}) {
+  return ProviderContainer(
+    overrides: [
+      updatedRemoteConfigKeysProvider.overrideWith(
+        () => _FakeUpdatedRemoteConfigKeys(),
+      ),
+      minimumBuildNumberProvider.overrideWith((ref) => null),
+      currentAppVersionProvider.overrideWith(
+        (ref) async => AppVersion(version: '1.0.0', buildNumber: 1),
+      ),
+      currentAppSessionProvider.overrideWith(() => currentAppSession),
+      lastTalkedCavivaraIdProvider.overrideWith(() => lastTalked),
+    ],
+  );
+}
+
+void main() {
+  group('appInitialRoute', () {
+    test('returns home with last talked Cavivara when available', () async {
+      const lastTalkedId = 'cavivara_mascot';
+      final currentSession = _FakeCurrentAppSession(
+        initialSession: AppSession.signedIn(counterId: 'house', isPro: false),
+      );
+      final lastTalked = _FakeLastTalkedCavivaraId(lastTalkedId);
+      final container = _createContainer(
+        currentAppSession: currentSession,
+        lastTalked: lastTalked,
+      );
+      addTearDown(container.dispose);
+
+      final route = await container.read(appInitialRouteProvider.future);
+
+      expect(
+        route,
+        const AppInitialRoute.home(cavivaraId: lastTalkedId),
+      );
+      expect(currentSession.ensureCalled, isFalse);
+    });
+
+    test('returns home with default Cavivara when last talked is absent',
+        () async {
+      final currentSession = _FakeCurrentAppSession(
+        initialSession: AppSession.signedIn(counterId: 'house', isPro: false),
+      );
+      final lastTalked = _FakeLastTalkedCavivaraId(null);
+      final container = _createContainer(
+        currentAppSession: currentSession,
+        lastTalked: lastTalked,
+      );
+      addTearDown(container.dispose);
+
+      final route = await container.read(appInitialRouteProvider.future);
+
+      expect(
+        route,
+        const AppInitialRoute.home(
+          cavivaraId: HomeScreen.defaultCavivaraId,
+        ),
+      );
+      expect(currentSession.ensureCalled, isFalse);
+    });
+
+    test('signs in anonymously when not signed in and opens default chat',
+        () async {
+      final currentSession = _FakeCurrentAppSession(
+        initialSession: AppSession.notSignedIn(),
+      );
+      final lastTalked = _FakeLastTalkedCavivaraId(null);
+      final container = _createContainer(
+        currentAppSession: currentSession,
+        lastTalked: lastTalked,
+      );
+      addTearDown(container.dispose);
+
+      final route = await container.read(appInitialRouteProvider.future);
+
+      expect(
+        route,
+        const AppInitialRoute.home(
+          cavivaraId: HomeScreen.defaultCavivaraId,
+        ),
+      );
+      expect(currentSession.ensureCalled, isTrue);
+      final sessionValue = container.read(currentAppSessionProvider).valueOrNull;
+      expect(sessionValue, isA<AppSessionSignedIn>());
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- ensure the app signs the user in anonymously when no session exists and route straight to the Cavivara chat
- default the initial chat target to Cavivara when no last conversation is stored
- cover the new initial routing behaviour with provider-level tests

## Testing
- flutter test *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d133fa95b48327b7bc4fd05786a4cf