### PR TITLE
feat: チャット領域をタップした際にソフトキーボードが閉じる機能を追加

### DIFF
--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -103,10 +103,14 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final body = Column(
       children: [
         Expanded(
-          child: _ChatMessageList(
-            controller: _scrollController,
-            onMessageSent: _onMessageSent,
-            cavivaraId: widget.cavivaraId,
+          child: GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTap: _dismissKeyboard,
+            child: _ChatMessageList(
+              controller: _scrollController,
+              onMessageSent: _onMessageSent,
+              cavivaraId: widget.cavivaraId,
+            ),
           ),
         ),
         _messageInput(),
@@ -180,6 +184,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           .sendMessage(message);
       _messageController.clear();
     }
+  }
+
+  void _dismissKeyboard() {
+    FocusScope.of(context).unfocus();
   }
 
   void _onMessageSent() {


### PR DESCRIPTION
## Summary
- wrap the chat message list with a gesture detector to watch for taps
- unfocus the current text field when the chat area is tapped to dismiss the keyboard

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d3f10c278c83279107dfd7de0d0879