### PR TITLE
fix: 履歴書画面で操作ミスで解雇してしまう問題を解消するため、アクションのレイアウトを整理して解雇前の確認を追加

### DIFF
--- a/client/lib/ui/component/fire_confirmation_dialog.dart
+++ b/client/lib/ui/component/fire_confirmation_dialog.dart
@@ -7,7 +7,30 @@ class FireConfirmationDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return AlertDialog(
       title: const Text('解雇しますか？'),
-      content: const Text('解雇すると、再度雇用するまで会議できなくなります。'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('解雇すると、再度雇用するまで会議できなくなります。'),
+          const SizedBox(height: 16),
+          Text(
+            '生活が苦しくなるヴィヴァ...',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              fontStyle: FontStyle.italic,
+              color: Theme.of(context).dividerColor,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(left: 8, top: 4),
+            child: Text(
+              '— カヴィヴァラさん',
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                color: Theme.of(context).dividerColor,
+              ),
+            ),
+          ),
+        ],
+      ),
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(true),

--- a/client/lib/ui/component/fire_confirmation_dialog.dart
+++ b/client/lib/ui/component/fire_confirmation_dialog.dart
@@ -7,15 +7,18 @@ class FireConfirmationDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return AlertDialog(
       title: const Text('解雇しますか？'),
-      content: const Text('本当に解雇すると、再度雇用するまで相談できなくなります。'),
+      content: const Text('解雇すると、再度雇用するまで会議できなくなります。'),
       actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: Text(
+            '解雇する',
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+        ),
         TextButton(
           onPressed: () => Navigator.of(context).pop(false),
           child: const Text('キャンセル'),
-        ),
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(true),
-          child: const Text('解雇する'),
         ),
       ],
     );

--- a/client/lib/ui/component/fire_confirmation_dialog.dart
+++ b/client/lib/ui/component/fire_confirmation_dialog.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class FireConfirmationDialog extends StatelessWidget {
+  const FireConfirmationDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('解雇しますか？'),
+      content: const Text('本当に解雇すると、再度雇用するまで相談できなくなります。'),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('キャンセル'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('解雇する'),
+        ),
+      ],
+    );
+  }
+}

--- a/client/lib/ui/feature/resume/resume_screen.dart
+++ b/client/lib/ui/feature/resume/resume_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:house_worker/data/service/cavivara_directory_service.dart';
 import 'package:house_worker/data/service/employment_state_service.dart';
 import 'package:house_worker/ui/component/cavivara_avatar.dart';
+import 'package:house_worker/ui/component/fire_confirmation_dialog.dart';
 import 'package:house_worker/ui/feature/home/home_screen.dart';
 import 'package:house_worker/ui/feature/job_market/job_market_screen.dart';
 
@@ -169,6 +170,11 @@ class _ResumeScreenState extends ConsumerState<ResumeScreen> {
                 if (isEmployed) ...[
                   ElevatedButton.icon(
                     onPressed: () async {
+                      final confirmed = await _showFireConfirmationDialog();
+                      if (!confirmed) {
+                        return;
+                      }
+
                       await _fireAndNavigateToJobMarket(
                         employmentStateNotifier,
                       );
@@ -241,5 +247,18 @@ class _ResumeScreenState extends ConsumerState<ResumeScreen> {
       HomeScreen.route(widget.cavivaraId),
       (route) => false,
     );
+  }
+
+  Future<bool> _showFireConfirmationDialog() async {
+    if (!mounted) {
+      return false;
+    }
+
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) => const FireConfirmationDialog(),
+    );
+
+    return result ?? false;
   }
 }

--- a/client/lib/ui/feature/resume/resume_screen.dart
+++ b/client/lib/ui/feature/resume/resume_screen.dart
@@ -166,8 +166,14 @@ class _ResumeScreenState extends ConsumerState<ResumeScreen> {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.stretch,
+              spacing: 8,
               children: [
                 if (isEmployed) ...[
+                  OutlinedButton.icon(
+                    onPressed: _navigateToChat,
+                    icon: const Icon(Icons.chat),
+                    label: const Text('会議する'),
+                  ),
                   ElevatedButton.icon(
                     onPressed: () async {
                       final confirmed = await _showFireConfirmationDialog();
@@ -185,12 +191,6 @@ class _ResumeScreenState extends ConsumerState<ResumeScreen> {
                       foregroundColor: theme.colorScheme.onError,
                       backgroundColor: theme.colorScheme.error,
                     ),
-                  ),
-                  const SizedBox(height: 8),
-                  OutlinedButton.icon(
-                    onPressed: _navigateToChat,
-                    icon: const Icon(Icons.chat),
-                    label: const Text('相談する'),
                   ),
                 ] else ...[
                   ElevatedButton.icon(

--- a/client/test/ui/feature/resume/resume_screen_test.dart
+++ b/client/test/ui/feature/resume/resume_screen_test.dart
@@ -60,13 +60,21 @@ void main() {
         // 雇用するボタンが表示されることを確認
         expect(find.text('雇用する'), findsOneWidget);
         expect(find.text('解雇する'), findsNothing);
-        expect(find.text('相談する'), findsNothing);
+        expect(find.text('会議する'), findsNothing);
       },
     );
 
     testWidgets(
       'shows fire and consult buttons when cavivara is employed',
       (WidgetTester tester) async {
+        SharedPreferences.setMockInitialValues({
+          PreferenceKey.employedCavivaraIds.name: [testCavivaraId],
+        });
+        SharedPreferencesAsyncPlatform.instance =
+            InMemorySharedPreferencesAsync.withData({
+              PreferenceKey.employedCavivaraIds.name: [testCavivaraId],
+            });
+
         await tester.pumpWidget(
           const ProviderScope(
             child: MaterialApp(
@@ -77,9 +85,9 @@ void main() {
 
         await tester.pumpAndSettle();
 
-        // 解雇ボタンと相談ボタンが表示されることを確認
+        // 解雇ボタンと会議ボタンが表示されることを確認
         expect(find.text('解雇する'), findsOneWidget);
-        expect(find.text('相談する'), findsOneWidget);
+        expect(find.text('会議する'), findsOneWidget);
         expect(find.text('雇用する'), findsNothing);
       },
     );
@@ -113,9 +121,9 @@ void main() {
         // 初期状態: 雇用するボタンのみ
         expect(find.text('雇用する'), findsOneWidget);
         expect(find.text('解雇する'), findsNothing);
-        expect(find.text('相談する'), findsNothing);
+        expect(find.text('会議する'), findsNothing);
 
-        // 雇用後: 解雇と相談ボタン
+        // 雇用後: 解雇と会議ボタン
         await container
             .read(employmentStateProvider.notifier)
             .hire(testCavivaraId);
@@ -123,7 +131,7 @@ void main() {
 
         expect(find.text('雇用する'), findsNothing);
         expect(find.text('解雇する'), findsOneWidget);
-        expect(find.text('相談する'), findsOneWidget);
+        expect(find.text('会議する'), findsOneWidget);
 
         // 解雇後: 雇用するボタンのみ
         await container
@@ -133,7 +141,7 @@ void main() {
 
         expect(find.text('雇用する'), findsOneWidget);
         expect(find.text('解雇する'), findsNothing);
-        expect(find.text('相談する'), findsNothing);
+        expect(find.text('会議する'), findsNothing);
       },
     );
 


### PR DESCRIPTION
## Summary
- add a confirmation dialog component for firing a Cavivara
- require confirmation before navigating away from the resume screen when firing

## Testing
- not run (Flutter tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68d544ce6cfc8327a04d43274292860b