### PR TITLE
fix: ソフトキーボード表示時にメッセージ入力欄の下部の余白が広すぎる問題を修正

### DIFF
--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -195,11 +195,14 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   }
 
   Widget _messageInput() {
+    final mediaQuery = MediaQuery.of(context);
+    final safeBottomPadding = mediaQuery.padding.bottom;
+
     return Container(
       padding: EdgeInsets.only(
-        left: 16 + MediaQuery.of(context).viewPadding.left,
-        right: 16 + MediaQuery.of(context).viewPadding.right,
-        bottom: 16 + MediaQuery.of(context).viewPadding.bottom,
+        left: 16 + mediaQuery.viewPadding.left,
+        right: 16 + mediaQuery.viewPadding.right,
+        bottom: 16 + safeBottomPadding,
         top: 16,
       ),
       decoration: BoxDecoration(

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -198,9 +198,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     return Container(
       padding: EdgeInsets.only(
         left: 16 + MediaQuery.of(context).viewPadding.left,
+        top: 16,
         right: 16 + MediaQuery.of(context).viewPadding.right,
         bottom: 16 + MediaQuery.of(context).padding.bottom,
-        top: 16,
       ),
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surface,

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -195,14 +195,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   }
 
   Widget _messageInput() {
-    final mediaQuery = MediaQuery.of(context);
-    final safeBottomPadding = mediaQuery.padding.bottom;
-
     return Container(
       padding: EdgeInsets.only(
-        left: 16 + mediaQuery.viewPadding.left,
-        right: 16 + mediaQuery.viewPadding.right,
-        bottom: 16 + safeBottomPadding,
+        left: 16 + MediaQuery.of(context).viewPadding.left,
+        right: 16 + MediaQuery.of(context).viewPadding.right,
+        bottom: 16 + MediaQuery.of(context).padding.bottom,
         top: 16,
       ),
       decoration: BoxDecoration(


### PR DESCRIPTION
## Summary
- rely on `MediaQuery.padding.bottom` for the chat input safe-area spacing so it naturally excludes the keyboard height

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68d78c77a3e4832784b412092ba5d584