### PR TITLE
feat: 最初の質問例を提示して会話を開始しやすくする機能を追加

### DIFF
--- a/client/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/client/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/flutterfire",
       "state" : {
-        "revision" : "f269819f310b935cf585571d1f3c9089f2f00186",
-        "version" : "4.1.0-firebase-core-swift"
+        "revision" : "032a707dfc773f8dda1832635d2c969cfb426a14",
+        "version" : "4.1.1-firebase-core-swift"
       }
     },
     {

--- a/client/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/client/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/flutterfire",
       "state" : {
-        "revision" : "032a707dfc773f8dda1832635d2c969cfb426a14",
-        "version" : "4.1.1-firebase-core-swift"
+        "revision" : "f269819f310b935cf585571d1f3c9089f2f00186",
+        "version" : "4.1.0-firebase-core-swift"
       }
     },
     {

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -412,26 +412,33 @@ class _ChatSuggestions extends StatelessWidget {
             ? constraints.maxHeight
             : 0.0;
 
+        final title = Text(
+          '質問してみましょう',
+          style: Theme.of(context).textTheme.titleMedium,
+        );
+
         return SingleChildScrollView(
-          padding: EdgeInsets.only(
-            left: 16 + MediaQuery.of(context).viewPadding.left,
-            right: 16 + MediaQuery.of(context).viewPadding.right,
-            top: 32,
-            bottom: 32,
-          ),
+          padding: const EdgeInsets.symmetric(vertical: 32),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             spacing: 16,
             children: [
-              Text(
-                '質問してみましょう',
-                style: Theme.of(context).textTheme.titleMedium,
+              Padding(
+                padding: EdgeInsets.only(
+                  left: 16 + MediaQuery.of(context).viewPadding.left,
+                  right: 16 + MediaQuery.of(context).viewPadding.right,
+                ),
+                child: title,
               ),
               SizedBox(
                 height: 136,
                 child: ListView.separated(
-                  primary: false,
                   scrollDirection: Axis.horizontal,
+                  primary: false,
+                  padding: EdgeInsets.only(
+                    left: 16 + MediaQuery.of(context).viewPadding.left,
+                    right: 16 + MediaQuery.of(context).viewPadding.right,
+                  ),
                   itemBuilder: (context, index) {
                     final suggestion = _suggestions[index];
                     return _SuggestionCard(

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -406,55 +406,47 @@ class _ChatSuggestions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final minHeight = constraints.maxHeight.isFinite
-            ? constraints.maxHeight
-            : 0.0;
+    final title = Text(
+      '質問してみましょう',
+      style: Theme.of(context).textTheme.titleMedium,
+    );
 
-        final title = Text(
-          '質問してみましょう',
-          style: Theme.of(context).textTheme.titleMedium,
-        );
-
-        return SingleChildScrollView(
-          padding: const EdgeInsets.symmetric(vertical: 32),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            spacing: 16,
-            children: [
-              Padding(
-                padding: EdgeInsets.only(
-                  left: 16 + MediaQuery.of(context).viewPadding.left,
-                  right: 16 + MediaQuery.of(context).viewPadding.right,
-                ),
-                child: title,
-              ),
-              SizedBox(
-                height: 136,
-                child: ListView.separated(
-                  scrollDirection: Axis.horizontal,
-                  primary: false,
-                  padding: EdgeInsets.only(
-                    left: 16 + MediaQuery.of(context).viewPadding.left,
-                    right: 16 + MediaQuery.of(context).viewPadding.right,
-                  ),
-                  itemBuilder: (context, index) {
-                    final suggestion = _suggestions[index];
-                    return _SuggestionCard(
-                      icon: suggestion.icon,
-                      label: suggestion.label,
-                      onTap: () => onSuggestionSelected(suggestion.label),
-                    );
-                  },
-                  separatorBuilder: (_, _) => const SizedBox(width: 12),
-                  itemCount: _suggestions.length,
-                ),
-              ),
-            ],
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(vertical: 32),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 16,
+        children: [
+          Padding(
+            padding: EdgeInsets.only(
+              left: 16 + MediaQuery.of(context).viewPadding.left,
+              right: 16 + MediaQuery.of(context).viewPadding.right,
+            ),
+            child: title,
           ),
-        );
-      },
+          SizedBox(
+            height: 136,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              primary: false,
+              padding: EdgeInsets.only(
+                left: 16 + MediaQuery.of(context).viewPadding.left,
+                right: 16 + MediaQuery.of(context).viewPadding.right,
+              ),
+              itemBuilder: (context, index) {
+                final suggestion = _suggestions[index];
+                return _SuggestionCard(
+                  icon: suggestion.icon,
+                  label: suggestion.label,
+                  onTap: () => onSuggestionSelected(suggestion.label),
+                );
+              },
+              separatorBuilder: (_, _) => const SizedBox(width: 12),
+              itemCount: _suggestions.length,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -403,8 +403,6 @@ class _ChatSuggestions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
     return LayoutBuilder(
       builder: (context, constraints) {
         final minHeight = constraints.maxHeight.isFinite
@@ -422,15 +420,15 @@ class _ChatSuggestions extends StatelessWidget {
             constraints: BoxConstraints(minHeight: minHeight),
             child: Column(
               mainAxisAlignment: minHeight > 0
-                  ? MainAxisAlignment.center
+                  ? MainAxisAlignment.end
                   : MainAxisAlignment.start,
               crossAxisAlignment: CrossAxisAlignment.start,
+              spacing: 16,
               children: [
                 Text(
                   '質問してみましょう',
-                  style: theme.textTheme.titleMedium,
+                  style: Theme.of(context).textTheme.titleMedium,
                 ),
-                const SizedBox(height: 16),
                 SizedBox(
                   height: 136,
                   child: ListView.separated(
@@ -470,9 +468,6 @@ class _SuggestionCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-
     return SizedBox(
       width: 240,
       child: InkWell(
@@ -481,10 +476,14 @@ class _SuggestionCard extends StatelessWidget {
         child: Ink(
           padding: const EdgeInsets.all(20),
           decoration: BoxDecoration(
-            color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.6),
-            borderRadius: BorderRadius.circular(20),
+            color: Theme.of(
+              context,
+            ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.6),
+            borderRadius: BorderRadius.circular(2),
             border: Border.all(
-              color: colorScheme.outline.withValues(alpha: 0.4),
+              color: Theme.of(
+                context,
+              ).colorScheme.outline.withValues(alpha: 0.4),
             ),
           ),
           child: Column(
@@ -492,13 +491,13 @@ class _SuggestionCard extends StatelessWidget {
             children: [
               Icon(
                 icon,
-                color: colorScheme.primary,
+                color: Theme.of(context).colorScheme.primary,
               ),
               const Spacer(),
               Text(
                 label,
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  color: colorScheme.onSurface,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
               ),
             ],

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -345,7 +345,7 @@ class _ChatMessageListState extends ConsumerState<_ChatMessageList> {
         );
       },
     );
-}
+  }
 
   void _sendSuggestion(String message) {
     ref
@@ -386,7 +386,7 @@ class _ChatSuggestions extends StatelessWidget {
 
   final ValueChanged<String> onSuggestionSelected;
 
-  static const _suggestions = [
+  static const List<({IconData icon, String label})> _suggestions = [
     (
       icon: Icons.queue_music,
       label: 'マンドリンの演奏会の選曲会議で何を出すか迷っています',
@@ -407,8 +407,9 @@ class _ChatSuggestions extends StatelessWidget {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        final minHeight =
-            constraints.maxHeight.isFinite ? constraints.maxHeight : 0;
+        final minHeight = constraints.maxHeight.isFinite
+            ? constraints.maxHeight
+            : 0.0;
 
         return SingleChildScrollView(
           padding: EdgeInsets.only(
@@ -420,8 +421,9 @@ class _ChatSuggestions extends StatelessWidget {
           child: ConstrainedBox(
             constraints: BoxConstraints(minHeight: minHeight),
             child: Column(
-              mainAxisAlignment:
-                  minHeight > 0 ? MainAxisAlignment.center : MainAxisAlignment.start,
+              mainAxisAlignment: minHeight > 0
+                  ? MainAxisAlignment.center
+                  : MainAxisAlignment.start,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
@@ -442,7 +444,7 @@ class _ChatSuggestions extends StatelessWidget {
                         onTap: () => onSuggestionSelected(suggestion.label),
                       );
                     },
-                    separatorBuilder: (_, __) => const SizedBox(width: 12),
+                    separatorBuilder: (_, _) => const SizedBox(width: 12),
                     itemCount: _suggestions.length,
                   ),
                 ),
@@ -479,10 +481,10 @@ class _SuggestionCard extends StatelessWidget {
         child: Ink(
           padding: const EdgeInsets.all(20),
           decoration: BoxDecoration(
-            color: colorScheme.surfaceVariant.withOpacity(0.6),
+            color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.6),
             borderRadius: BorderRadius.circular(20),
             border: Border.all(
-              color: colorScheme.outline.withOpacity(0.4),
+              color: colorScheme.outline.withValues(alpha: 0.4),
             ),
           ),
           child: Column(

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -525,9 +525,6 @@ class _UserChatBubble extends StatelessWidget {
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.primaryContainer,
         borderRadius: BorderRadius.circular(2),
-        border: Border(
-          bottom: BorderSide(color: Theme.of(context).colorScheme.primary),
-        ),
       ),
       child: bodyText,
     );
@@ -617,9 +614,6 @@ class _AiChatBubble extends ConsumerWidget {
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(2),
-        border: Border(
-          bottom: BorderSide(color: Theme.of(context).colorScheme.primary),
-        ),
       ),
       child: bodyText,
     );
@@ -679,9 +673,6 @@ class _AppChatBubble extends ConsumerWidget {
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surfaceContainer.withAlpha(100),
         borderRadius: BorderRadius.circular(2),
-        border: Border(
-          bottom: BorderSide(color: Theme.of(context).colorScheme.primary),
-        ),
       ),
       child: bodyText,
     );

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -320,8 +320,11 @@ class _ChatMessageListState extends ConsumerState<_ChatMessageList> {
     _previousHasStreamingMessages = hasStreamingMessages;
 
     if (messages.isEmpty) {
-      return _ChatSuggestions(
-        onSuggestionSelected: _sendSuggestion,
+      return Align(
+        alignment: Alignment.bottomCenter,
+        child: _ChatSuggestions(
+          onSuggestionSelected: _sendSuggestion,
+        ),
       );
     }
 
@@ -416,38 +419,32 @@ class _ChatSuggestions extends StatelessWidget {
             top: 32,
             bottom: 32,
           ),
-          child: ConstrainedBox(
-            constraints: BoxConstraints(minHeight: minHeight),
-            child: Column(
-              mainAxisAlignment: minHeight > 0
-                  ? MainAxisAlignment.end
-                  : MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              spacing: 16,
-              children: [
-                Text(
-                  '質問してみましょう',
-                  style: Theme.of(context).textTheme.titleMedium,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            spacing: 16,
+            children: [
+              Text(
+                '質問してみましょう',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              SizedBox(
+                height: 136,
+                child: ListView.separated(
+                  primary: false,
+                  scrollDirection: Axis.horizontal,
+                  itemBuilder: (context, index) {
+                    final suggestion = _suggestions[index];
+                    return _SuggestionCard(
+                      icon: suggestion.icon,
+                      label: suggestion.label,
+                      onTap: () => onSuggestionSelected(suggestion.label),
+                    );
+                  },
+                  separatorBuilder: (_, _) => const SizedBox(width: 12),
+                  itemCount: _suggestions.length,
                 ),
-                SizedBox(
-                  height: 136,
-                  child: ListView.separated(
-                    primary: false,
-                    scrollDirection: Axis.horizontal,
-                    itemBuilder: (context, index) {
-                      final suggestion = _suggestions[index];
-                      return _SuggestionCard(
-                        icon: suggestion.icon,
-                        label: suggestion.label,
-                        onTap: () => onSuggestionSelected(suggestion.label),
-                      );
-                    },
-                    separatorBuilder: (_, _) => const SizedBox(width: 12),
-                    itemCount: _suggestions.length,
-                  ),
-                ),
-              ],
-            ),
+              ),
+            ],
           ),
         );
       },
@@ -468,39 +465,35 @@ class _SuggestionCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final indicatorIcon = Icon(
+      icon,
+      color: Theme.of(context).colorScheme.primary,
+    );
+    final bodyText = Text(
+      label,
+      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+        color: Theme.of(context).colorScheme.onSurface,
+      ),
+    );
+
     return SizedBox(
       width: 240,
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(20),
-        child: Ink(
-          padding: const EdgeInsets.all(20),
-          decoration: BoxDecoration(
-            color: Theme.of(
-              context,
-            ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.6),
-            borderRadius: BorderRadius.circular(2),
-            border: Border.all(
-              color: Theme.of(
-                context,
-              ).colorScheme.outline.withValues(alpha: 0.4),
+      child: Card(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(2),
+        ),
+        child: InkWell(
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              spacing: 16,
+              children: [
+                indicatorIcon,
+                bodyText,
+              ],
             ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Icon(
-                icon,
-                color: Theme.of(context).colorScheme.primary,
-              ),
-              const Spacer(),
-              Text(
-                label,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurface,
-                ),
-              ),
-            ],
           ),
         ),
       ),

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -320,14 +320,8 @@ class _ChatMessageListState extends ConsumerState<_ChatMessageList> {
     _previousHasStreamingMessages = hasStreamingMessages;
 
     if (messages.isEmpty) {
-      return const Center(
-        child: Padding(
-          padding: EdgeInsets.all(16),
-          child: Text(
-            'AIとチャットを始めましょう！\n下のテキストフィールドにメッセージを入力してください。',
-            textAlign: TextAlign.center,
-          ),
-        ),
+      return _ChatSuggestions(
+        onSuggestionSelected: _sendSuggestion,
       );
     }
 
@@ -351,6 +345,13 @@ class _ChatMessageListState extends ConsumerState<_ChatMessageList> {
         );
       },
     );
+}
+
+  void _sendSuggestion(String message) {
+    ref
+        .read(chatMessagesProvider(widget.cavivaraId).notifier)
+        .sendMessage(message);
+    widget.onMessageSent();
   }
 }
 
@@ -375,6 +376,134 @@ class _ChatBubble extends ConsumerWidget {
         message: message,
       ),
     };
+  }
+}
+
+class _ChatSuggestions extends StatelessWidget {
+  const _ChatSuggestions({
+    required this.onSuggestionSelected,
+  });
+
+  final ValueChanged<String> onSuggestionSelected;
+
+  static const _suggestions = [
+    (
+      icon: Icons.queue_music,
+      label: 'マンドリンの演奏会の選曲会議で何を出すか迷っています',
+    ),
+    (
+      icon: Icons.group,
+      label: 'プレクトラム結社の最新の演奏会について教えて',
+    ),
+    (
+      icon: Icons.restaurant_menu,
+      label: '今晩の夜ご飯のレシピを考えて',
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final minHeight =
+            constraints.maxHeight.isFinite ? constraints.maxHeight : 0;
+
+        return SingleChildScrollView(
+          padding: EdgeInsets.only(
+            left: 16 + MediaQuery.of(context).viewPadding.left,
+            right: 16 + MediaQuery.of(context).viewPadding.right,
+            top: 32,
+            bottom: 32,
+          ),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: minHeight),
+            child: Column(
+              mainAxisAlignment:
+                  minHeight > 0 ? MainAxisAlignment.center : MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '質問してみましょう',
+                  style: theme.textTheme.titleMedium,
+                ),
+                const SizedBox(height: 16),
+                SizedBox(
+                  height: 136,
+                  child: ListView.separated(
+                    primary: false,
+                    scrollDirection: Axis.horizontal,
+                    itemBuilder: (context, index) {
+                      final suggestion = _suggestions[index];
+                      return _SuggestionCard(
+                        icon: suggestion.icon,
+                        label: suggestion.label,
+                        onTap: () => onSuggestionSelected(suggestion.label),
+                      );
+                    },
+                    separatorBuilder: (_, __) => const SizedBox(width: 12),
+                    itemCount: _suggestions.length,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _SuggestionCard extends StatelessWidget {
+  const _SuggestionCard({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return SizedBox(
+      width: 240,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(20),
+        child: Ink(
+          padding: const EdgeInsets.all(20),
+          decoration: BoxDecoration(
+            color: colorScheme.surfaceVariant.withOpacity(0.6),
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(
+              color: colorScheme.outline.withOpacity(0.4),
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                icon,
+                color: colorScheme.primary,
+              ),
+              const Spacer(),
+              Text(
+                label,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurface,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the empty chat placeholder with a suggestion panel that mirrors the provided design inspiration
- add three quick actions for first-time prompts and wire them to send the selected message

## Testing
- not run (Flutter tooling is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_b_68de65f1c1088327ab9f70ddf28d960d