### PR TITLE
feat: カヴィヴァラさんが現在の日時を把握できるように知識をインプット

### DIFF
--- a/client/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/client/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/flutterfire",
       "state" : {
-        "revision" : "f269819f310b935cf585571d1f3c9089f2f00186",
-        "version" : "4.1.0-firebase-core-swift"
+        "revision" : "032a707dfc773f8dda1832635d2c969cfb426a14",
+        "version" : "4.1.1-firebase-core-swift"
       }
     },
     {

--- a/client/lib/data/service/cavivara_knowledge_service.dart
+++ b/client/lib/data/service/cavivara_knowledge_service.dart
@@ -123,10 +123,10 @@ class CavivaraKnowledgeBase {
   }
 
   static Map<String, dynamic> _getCurrentDateTime() {
-    final nowUtc = DateTime.now().toUtc();
+    final current = DateTime.now();
     return {
-      'utcDateTime': nowUtc.toIso8601String(),
-      'epochMilliseconds': nowUtc.millisecondsSinceEpoch,
+      'dateTime': current.toString(),
+      'epochMilliseconds': current.millisecondsSinceEpoch,
     };
   }
 
@@ -148,7 +148,7 @@ class CavivaraKnowledgeBase {
   static FunctionDeclaration _buildCurrentDateTimeFunctionDeclaration() {
     return FunctionDeclaration(
       _currentDateTimeFunctionName,
-      '現在のUTC日時情報を取得します。',
+      '現在の日時情報を取得します。',
       parameters: {},
     );
   }

--- a/client/lib/data/service/cavivara_knowledge_service.dart
+++ b/client/lib/data/service/cavivara_knowledge_service.dart
@@ -146,9 +146,10 @@ class CavivaraKnowledgeBase {
   }
 
   static FunctionDeclaration _buildCurrentDateTimeFunctionDeclaration() {
-    return const FunctionDeclaration(
+    return FunctionDeclaration(
       _currentDateTimeFunctionName,
       '現在のUTC日時情報を取得します。',
+      parameters: {},
     );
   }
 

--- a/client/lib/data/service/cavivara_knowledge_service.dart
+++ b/client/lib/data/service/cavivara_knowledge_service.dart
@@ -13,7 +13,8 @@ class CavivaraKnowledgeBase {
 
   static final Logger _logger = Logger('CavivaraKnowledgeBase');
 
-  static const String _functionName = 'getPlectrumSocietyKnowledge';
+  static const String _knowledgeFunctionName = 'getPlectrumSocietyKnowledge';
+  static const String _currentDateTimeFunctionName = 'getCurrentDateTime';
 
   static const Map<String, _KnowledgeEntry> _entries = {
     'salary_policy': _KnowledgeEntry(
@@ -59,7 +60,10 @@ class CavivaraKnowledgeBase {
   };
 
   static final List<Tool> _knowledgeTools = List.unmodifiable([
-    Tool.functionDeclarations([_buildFunctionDeclaration()]),
+    Tool.functionDeclarations([
+      _buildKnowledgeFunctionDeclaration(),
+      _buildCurrentDateTimeFunctionDeclaration(),
+    ]),
   ]);
 
   List<Tool> get tools => _knowledgeTools;
@@ -68,16 +72,26 @@ class CavivaraKnowledgeBase {
     required String functionName,
     Map<String, dynamic> arguments = const <String, dynamic>{},
   }) async {
-    if (functionName != _functionName) {
-      _logger.warning('Unknown function call requested: $functionName');
-      return {
-        'found': false,
-        'message': '未対応の関数が指定されました。',
-        'requestedFunction': functionName,
-        'availableFunctions': [_functionName],
-      };
+    switch (functionName) {
+      case _knowledgeFunctionName:
+        return _getKnowledge(arguments);
+      case _currentDateTimeFunctionName:
+        return _getCurrentDateTime();
+      default:
+        _logger.warning('Unknown function call requested: $functionName');
+        return {
+          'found': false,
+          'message': '未対応の関数が指定されました。',
+          'requestedFunction': functionName,
+          'availableFunctions': const [
+            _knowledgeFunctionName,
+            _currentDateTimeFunctionName,
+          ],
+        };
     }
+  }
 
+  static Map<String, dynamic> _getKnowledge(Map<String, dynamic> arguments) {
     final resolvedTopic = _resolveTopic(
       topic: arguments['topic'],
       query: arguments['query'],
@@ -108,9 +122,17 @@ class CavivaraKnowledgeBase {
     };
   }
 
-  static FunctionDeclaration _buildFunctionDeclaration() {
+  static Map<String, dynamic> _getCurrentDateTime() {
+    final nowUtc = DateTime.now().toUtc();
+    return {
+      'utcDateTime': nowUtc.toIso8601String(),
+      'epochMilliseconds': nowUtc.millisecondsSinceEpoch,
+    };
+  }
+
+  static FunctionDeclaration _buildKnowledgeFunctionDeclaration() {
     return FunctionDeclaration(
-      _functionName,
+      _knowledgeFunctionName,
       'プレクトラム結社に関する社内公式知識を取得します。',
       parameters: {
         'topic': Schema.string(
@@ -120,6 +142,13 @@ class CavivaraKnowledgeBase {
           description: '自然言語で記述された検索クエリ。例: "給料は？"',
         ),
       },
+    );
+  }
+
+  static FunctionDeclaration _buildCurrentDateTimeFunctionDeclaration() {
+    return const FunctionDeclaration(
+      _currentDateTimeFunctionName,
+      '現在のUTC日時情報を取得します。',
     );
   }
 

--- a/client/test/data/service/cavivara_knowledge_service_test.dart
+++ b/client/test/data/service/cavivara_knowledge_service_test.dart
@@ -58,5 +58,45 @@ void main() {
       expect(result['found'], isFalse);
       expect(result['availableTopics'], contains('salary_policy'));
     });
+
+    test('returns available functions when unknown function is requested', () async {
+      final result = await knowledgeBase.execute(
+        functionName: 'unknownFunction',
+      );
+
+      expect(result['found'], isFalse);
+      expect(result['requestedFunction'], 'unknownFunction');
+      final availableFunctions =
+          List<String>.from(result['availableFunctions'] as List<dynamic>);
+      expect(
+        availableFunctions,
+        containsAll(<String>['getPlectrumSocietyKnowledge', 'getCurrentDateTime']),
+      );
+    });
+
+    test('returns current date time information', () async {
+      final start = DateTime.now().toUtc();
+
+      final result = await knowledgeBase.execute(
+        functionName: 'getCurrentDateTime',
+      );
+
+      final end = DateTime.now().toUtc();
+
+      final utcDateTime = result['utcDateTime'] as String;
+      final parsedUtc = DateTime.parse(utcDateTime);
+      expect(parsedUtc.isUtc, isTrue);
+      expect(
+        parsedUtc.isAfter(start.subtract(const Duration(seconds: 5))),
+        isTrue,
+      );
+      expect(
+        parsedUtc.isBefore(end.add(const Duration(seconds: 5))),
+        isTrue,
+      );
+
+      final epochMilliseconds = result['epochMilliseconds'] as int;
+      expect(parsedUtc.millisecondsSinceEpoch, epochMilliseconds);
+    });
   });
 }

--- a/client/test/data/service/cavivara_knowledge_service_test.dart
+++ b/client/test/data/service/cavivara_knowledge_service_test.dart
@@ -90,20 +90,19 @@ void main() {
 
       final end = DateTime.now().toUtc();
 
-      final utcDateTime = result['utcDateTime'] as String;
-      final parsedUtc = DateTime.parse(utcDateTime);
-      expect(parsedUtc.isUtc, isTrue);
+      final dateTime = result['dateTime'] as String;
+      final parsed = DateTime.parse(dateTime);
       expect(
-        parsedUtc.isAfter(start.subtract(const Duration(seconds: 5))),
+        parsed.isAfter(start.subtract(const Duration(seconds: 5))),
         isTrue,
       );
       expect(
-        parsedUtc.isBefore(end.add(const Duration(seconds: 5))),
+        parsed.isBefore(end.add(const Duration(seconds: 5))),
         isTrue,
       );
 
       final epochMilliseconds = result['epochMilliseconds'] as int;
-      expect(parsedUtc.millisecondsSinceEpoch, epochMilliseconds);
+      expect(parsed.millisecondsSinceEpoch, epochMilliseconds);
     });
   });
 }

--- a/client/test/data/service/cavivara_knowledge_service_test.dart
+++ b/client/test/data/service/cavivara_knowledge_service_test.dart
@@ -59,20 +59,27 @@ void main() {
       expect(result['availableTopics'], contains('salary_policy'));
     });
 
-    test('returns available functions when unknown function is requested', () async {
-      final result = await knowledgeBase.execute(
-        functionName: 'unknownFunction',
-      );
+    test(
+      'returns available functions when unknown function is requested',
+      () async {
+        final result = await knowledgeBase.execute(
+          functionName: 'unknownFunction',
+        );
 
-      expect(result['found'], isFalse);
-      expect(result['requestedFunction'], 'unknownFunction');
-      final availableFunctions =
-          List<String>.from(result['availableFunctions'] as List<dynamic>);
-      expect(
-        availableFunctions,
-        containsAll(<String>['getPlectrumSocietyKnowledge', 'getCurrentDateTime']),
-      );
-    });
+        expect(result['found'], isFalse);
+        expect(result['requestedFunction'], 'unknownFunction');
+        final availableFunctions = List<String>.from(
+          result['availableFunctions'] as List<dynamic>,
+        );
+        expect(
+          availableFunctions,
+          containsAll(<String>[
+            'getPlectrumSocietyKnowledge',
+            'getCurrentDateTime',
+          ]),
+        );
+      },
+    );
 
     test('returns current date time information', () async {
       final start = DateTime.now().toUtc();


### PR DESCRIPTION
## Summary
- add a getCurrentDateTime function declaration alongside existing knowledge tools
- return the current UTC timestamp payload for AI function calls and list all available functions on errors
- extend coverage in CavivaraKnowledgeBase tests for the new function and unknown function handling

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68dfcc2267048327969a467503e22d62